### PR TITLE
Removed US Embassy PH domain

### DIFF
--- a/dotgovph-domains/domains.csv
+++ b/dotgovph-domains/domains.csv
@@ -99,7 +99,6 @@ comelec.gov.ph,Comelec
 nationalarchives.gov.ph,National Archives of the Philippines
 treasury.gov.ph,Bureau of Treasury
 caap.gov.ph,Civil Aviation Authority of the Philippines
-ph.usembassy.gov,U.S. Embassy in the Philippines
 peza.gov.ph,Philippine Economic Zone Authority
 coastguard.gov.ph,Philippine Coast Guard
 pnp.gov.ph,Philippine National Police
@@ -124,17 +123,17 @@ ritm.gov.ph,Research Institute For Topical Medicine
 pcw.gov.ph,Philippine commission on Women
 nsw.gov.ph,Philippines National Single Window
 finder.tariffcommission.gov.ph,Tariff Commision
-e-extension.gov.ph,e-Learning for Agriculture and fisheries 
+e-extension.gov.ph,e-Learning for Agriculture and fisheries
 e-tesda.gov.ph,Tesda Online Program
 owwa.gov.ph,Overseas Wrkers Welfair Administration
-nyc.gov.ph,National Youth Commission 
+nyc.gov.ph,National Youth Commission
 ogcc.gov.ph,Office of the Governement Corporate Counsel
 pttc.govph,Philippine Trade Training Center
 ncca.gov.ph,National Commission for Culture and the Arts
-phc.gov.ph,Philippine Heart Center 
+phc.gov.ph,Philippine Heart Center
 Marina.gov.ph,Maritime Industry Authority
 ots.gov.ph,Ofice for Transportation Security
-ppp.gov.ph,Public-Private Partnership Center 
+ppp.gov.ph,Public-Private Partnership Center
 blgf.go.ph,Bureau f Local Government Finance
 launion.gov.ph,Provincial Government of La Union
 tpb.gov.ph,Tourism Promotions Board Philippines
@@ -162,7 +161,7 @@ angelescity.gov.ph,Angeles City Local Governmet Website
 guimaras.gov.ph,Guimaras
 ppsc.gov.ph,Philippine Public Safety Colege
 picc.gov.ph,Philippine International Convention Center
-pcic.gov.ph,Philippine Crop Insurance Coporation 
+pcic.gov.ph,Philippine Crop Insurance Coporation
 bacolodcity.gov.ph,Bacolod City Government Center
 caloocancity.gov.ph,Coloocan City
 dfa-oavs.gov.ph,Overseas Absentee Voting Secretariat
@@ -177,7 +176,7 @@ napocor.gov.ph,National Power Corporation
 mgb.gov.ph,Mines and Geoscience Bureau
 bacoor.gov.ph,Bacoor Government Center
 psalm.gov.ph,PSALM Corporation
-tarlaccity.gov.ph,Tarlac City 
+tarlaccity.gov.ph,Tarlac City
 makati.gov.ph,Makati City Government
 cebu.gov.ph,Cebu Provincial Government
 nationalmuseum.gov.ph,National Museum of the Philippines
@@ -192,10 +191,10 @@ intramuros.gov.ph,Intramuros Administration
 miaa.gov.ph,Manila International Airport Authority
 cesboard.gov.ph,Career Executive Service Board
 pnvsca.gov.ph,Philippine Natonal Volunteer Service Coordinating Agency
-nha.gov.ph,National Housing Authority 
+nha.gov.ph,National Housing Authority
 quezoncity.gov.ph,QC
 probation.gov.ph,Parole and Probation Administration
-davaocity.gov.ph,Davao City 
+davaocity.gov.ph,Davao City
 paete.gov.ph,"Paete, Laguna"
 mandaluyong.gov.ph,Mandaluyong City
 cityogsanfemando.gov.ph,City of San Fernando
@@ -203,7 +202,7 @@ malabon.gov.ph,Malabon City
 mcwd.gov.ph,Metropolitan Cebu Water District
 agusandelsur.gov.ph,Agusan del Sur
 panay.gov.ph,Municipality of Panay
-pids.gov.ph,Philippine Institure for Development Studeis 
+pids.gov.ph,Philippine Institure for Development Studeis
 cainta.gov.ph,Cainta
 manila.gov.ph,City of Manila
 butuan.gov.ph,Butuan
@@ -211,13 +210,13 @@ ilocosnorte.gov.ph,Ilocos Norte
 pnpfs.gov.ph,PNP Finance Service
 lpp.gov.ph,League of Provinces of the Philippines Online
 pla.gov.ph,Philippine Information Agency
-benguet.gov.ph,Provnce of Benguet 
+benguet.gov.ph,Provnce of Benguet
 aklan.gov.ph,Aklan
-sarangani.gov.ph,Province of Government of Sarangani 
+sarangani.gov.ph,Province of Government of Sarangani
 lanadelnorte.gov.ph,Province of Lanao del Norte
 abra.gov.ph,Province of Abra
 basilan.gov.ph,Basilan Province
-pangasinan.go.ph,Pangasinan 
+pangasinan.go.ph,Pangasinan
 cotabatoprov.gov.ph,Province of Cotabato
 easteasternsamar.gov.ph,Province of Eastern Samar
 laguna.gov.ph,Pronvicial Government of Laguna
@@ -248,4 +247,4 @@ davaodelsur.gov.ph ,Pronvicial Government of Davao del Sur
 quezon.gov.ph,Pronvicial Government of Quezon
 palawan.gov.ph,Pronvicial Government of Palawan
 tagbilaran.gov.ph,City Government of Tagbilaran
-pagcwd.gov.ph,Pagadian City Water District 
+pagcwd.gov.ph,Pagadian City Water District


### PR DESCRIPTION
This PR removes the invalid domain of the US Embassy in the Philippines.